### PR TITLE
Feature/18 fix post merge hook

### DIFF
--- a/scripts/post-merge
+++ b/scripts/post-merge
@@ -7,7 +7,7 @@ echo "Starting post-merge hook"
 PATH=$PATH:/usr/local/bin:/usr/local/sbin # http://stackoverflow.com/questions/12881975/git-pre-commit-hook-failing-in-github-for-mac-works-on-command-line
 
 function changed {
-  git diff --name-only | grep "^$1" > /dev/null 2>&1
+  git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | grep "^$1" > /dev/null 2>&1
 }
 
 if changed 'src/webapp/server/migrations'; then

--- a/src/webapp/server/package.json
+++ b/src/webapp/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "start": "NODE_ENV=production nodemon ./bin/www",

--- a/src/webapp/server/package.json
+++ b/src/webapp/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "start": "NODE_ENV=production nodemon ./bin/www",


### PR DESCRIPTION
Fixes #18 

```
git -c diff.mnemonicprefix=false -c core.quotepath=false -c credential.helper=sourcetree merge feature/test 
Starting post-merge hook
Installing webapp server npm packages
Updating e594b04..0182afa
Fast-forward
 src/webapp/server/package.json | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
Done with post-merge hook
Completed successfully
```

However, I noticed that if there's a conflict and the merge fails, the post-merge hook never runs. This is by design from git. But when the conflict is resolved, there should be a way to run the hook. Edge case but something to be aware of.