### PR TITLE
Feature/27 circleci push

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,6 @@ The difference is `docker-production.yml` won't link your local code to the cont
 
 ## Deploying to Production
 
-When code is merged into `master`, CircleCI runs the integration tests. If they pass, CircleCI notifies DockerHub to rebuild the `webapp` container. Once the build finishes, DockerHub notifies Tutum to pull down the new image and swap it with the old container.
+When code is merged into `master`, CircleCI runs the integration tests. If they pass, CircleCI notifies DockerHub to rebuild the `webapp` container. Once the build finishes, DockerHub notifies Tutum to swap the old container with the new `webapp` image.
 
-The other containers are not deployed automatically because they rarely change. If they need updating, start a build on DockerHub and redeploy the container on Tutum. 
+The other containers are not deployed automatically because they rarely change. If they need updating, manually start a build on DockerHub and redeploy the container on Tutum.

--- a/README.md
+++ b/README.md
@@ -99,4 +99,8 @@ The difference is `docker-production.yml` won't link your local code to the cont
 
 When code is merged into `master`, CircleCI runs the integration tests. If they pass, CircleCI notifies DockerHub to rebuild the `webapp` container. Once the build finishes, DockerHub notifies Tutum to swap the old container with the new `webapp` image.
 
-The other containers are not deployed automatically because they rarely change. If they need updating, manually start a build on DockerHub and redeploy the container on Tutum.
+The other containers are not deployed automatically because they rarely change. If they need updating:
+
+1. On CircleCI, [clear the cache](https://circleci.com/docs/how-cache-works) and rerun the tests
+2. On DockerHub, manually start a build on the updated container
+3. On Tutum, redeploy the container

--- a/README.md
+++ b/README.md
@@ -84,14 +84,19 @@ When changing any of the other Dockerfiles, rebuild the images by running:
 Now you are ready for development again.
 
 
-## Building for Production
+## Running a Staging Environment
 
-To effectively run a staging environment on your machine, run:
+These are the same commands the integration tests on CircleCI run:
 
     $ (cd src; docker-compose -f docker-production.yml up -d)
     $ (cd src; docker-compose -f docker-production.yml run webapp grunt test --gruntfile /webapp/client/Gruntfile.js)
     $ curl http://$(boot2docker ip)
-    
-This difference is `docker-production.yml` won't link your local code to the container.
 
-Actually deploying to production is done automatically when code is merged to `master`.
+The difference is `docker-production.yml` won't link your local code to the container.
+
+
+## Deploying to Production
+
+When code is merged into `master`, CircleCI runs the integration tests. If they pass, CircleCI notifies DockerHub to rebuild the `webapp` container. Once the build finishes, DockerHub notifies Tutum to pull down the new image and swap it with the old container.
+
+The other containers are not deployed automatically because they rarely change. If they need updating, start a build on DockerHub and redeploy the container on Tutum. 

--- a/circle.yml
+++ b/circle.yml
@@ -24,8 +24,18 @@ dependencies:
     # Print the history so that we can investigate potential steps which fatten
     # the image needlessly.
     - docker history src_webapp
+    # Bring up the environment as a daemon (-d) to not block tests
     - (cd src; docker-compose -f docker-production.yml up -d)
 
 test:
   override:
     - (cd src; docker-compose -f docker-production.yml run webapp grunt test --gruntfile /webapp/client/Gruntfile.js)
+
+deployment:
+  hub:
+    # Notify DockerHub to build the new container once the tests pass
+    # Set on https://circleci.com/gh/league-wins-pool/league-wins-pool/edit#env-vars
+    # From https://blog.rainforestqa.com/2014-12-08-docker-in-action-from-deployment-to-delivery-part-2-continuous-integration/
+    branch: master
+    commands:
+      - $DEPLOY_WEBAPP


### PR DESCRIPTION
Inspired by https://blog.rainforestqa.com/2014-12-08-docker-in-action-from-deployment-to-delivery-part-2-continuous-integration/, I configured CircleCI to notify DockerHub to rebuild the `webapp` container instead of DockerHub doing it automatically after every push.